### PR TITLE
Fix startup crash: Axes.plot_date removed in matplotlib 3.11

### DIFF
--- a/src/linakdeskapp/gui/mpl/position_chart.py
+++ b/src/linakdeskapp/gui/mpl/position_chart.py
@@ -45,8 +45,10 @@ class PositionChart(DynamicMplCanvas):
         self.xdata = list()
         self.ydata = list()
 
-        linesList = self.plot.plot_date( self.xdata, self.ydata, 'r',
-                                         linewidth=3, antialiased=True)
+        ## matplotlib >=3.11 removed Axes.plot_date; use plot() and mark x-axis as dates
+        linesList = self.plot.plot( self.xdata, self.ydata, 'r',
+                                    linewidth=3, antialiased=True)
+        self.plot.xaxis_date()
         self.line = linesList[0]
 
 #         self.fig.suptitle('Desk position', y=0.95, fontsize=18)


### PR DESCRIPTION
## Problem

On a fresh install with current matplotlib (3.11), the app crashes immediately on startup:

```
File ".../linakdeskapp/gui/mpl/position_chart.py", line 48, in __init__
    linesList = self.plot.plot_date( self.xdata, self.ydata, 'r', ... )
AttributeError: 'Axes' object has no attribute 'plot_date'
```

`Axes.plot_date` was deprecated in matplotlib 3.9 and removed in 3.11, so the GUI never opens.

## Fix

Follow matplotlib's documented migration: replace `plot_date(x, y, fmt)` with `plot(x, y, fmt)` plus `Axes.xaxis_date()` to keep treating the x-axis values as dates. The existing `DateFormatter` and date ticks are unaffected, so chart behaviour is unchanged.

## Testing

Built and installed in a venv (Python 3.14, matplotlib 3.11). Before the change the app crashed on launch with the traceback above; after it, the main window opens and the position chart renders normally.